### PR TITLE
Recover transcription source and improve source provenance

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -47,8 +47,12 @@
 			&lt;p&gt;This ebook edition is based on the 1805 edition of &lt;i&gt;Lyrical Ballads&lt;/i&gt;, and features the famous poems &lt;i&gt;The Rime of the Ancient Mariner&lt;/i&gt;, “Tintern Abbey,” “Expostulation and Reply,” “Lucy Gray,” and many others.&lt;/p&gt;
 		</meta>
 		<dc:language>en-GB</dc:language>
-		<dc:source>http://archive.rc.umd.edu/editions/LB/html/Lb05-1.html</dc:source>
-		<dc:source>http://archive.rc.umd.edu/editions/LB/html/Lb05-2.html</dc:source>
+		<!--Volume I-->
+		<dc:source>https://web.archive.org/web/20211010215437/http://ec2-52-90-79-236.compute-1.amazonaws.com/cgi-bin/LB/sgml2html_lballads.pl?fname=Lb05-1.sgm</dc:source>
+		<dc:source>https://archive.org/details/lyricalballads01wordgoog</dc:source>
+		<!--Volume II-->
+		<dc:source>https://web.archive.org/web/20211010215601/http://ec2-52-90-79-236.compute-1.amazonaws.com/cgi-bin/LB/sgml2html_lballads.pl?fname=Lb05-2.sgm</dc:source>
+		<dc:source>https://archive.org/details/lyricalballadsw00wordgoog</dc:source>
 		<meta property="se:production-notes">Converted some archaic capitalizations to lowercase in the preface and endnotes.</meta>
 		<meta property="se:word-count">55524</meta>
 		<meta property="se:reading-ease.flesch">68.33</meta>

--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -22,7 +22,9 @@
 			and is based on a transcription produced in 2001 by<br/>
 			<b epub:type="z3998:personal-name">Bruce Graver</b> and <b epub:type="z3998:personal-name">Ronald Tetreault</b><br/>
 			for<br/>
-			<a href="http://archive.rc.umd.edu/editions/LB/html/Lb05-1.html">Romantic Circles</a>.</p>
+			<a href="http://romantic-circles.org/editions/LB/index.html">Romantic Circles</a><br/>
+			and on digital scans available at the<br/>
+			<b epub:type="z3998:organization">Internet Archive</b> (<abbr>vols.</abbr> <a href="https://archive.org/details/lyricalballads01wordgoog">I</a> and <a href="https://archive.org/details/lyricalballadsw00wordgoog">II</a>).</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting" xml:lang="de">Der Wanderer über dem Nebelmeer</i>,<br/>
 			a painting completed in 1818 by<br/>

--- a/src/epub/text/imprint.xhtml
+++ b/src/epub/text/imprint.xhtml
@@ -12,7 +12,7 @@
 				<img alt="The Standard Ebooks logo" src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
-			<p>This particular ebook is based on a transcription produced for <a href="http://archive.rc.umd.edu/editions/LB/html/Lb05-1.html">Romantic Circles</a>.</p>
+			<p>This particular ebook is based on a transcription produced for <a href="http://romantic-circles.org/editions/LB/index.html">Romantic Circles</a> and on digital scans available at the Internet Archive (<abbr>vols.</abbr> <a href="https://archive.org/details/lyricalballads01wordgoog">I</a> and <a href="https://archive.org/details/lyricalballadsw00wordgoog">II</a>).</p>
 			<p>The writing and artwork within are believed to be in the <abbr>U.S.</abbr> public domain, and Standard Ebooks releases this ebook edition under the terms in the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal Public Domain Dedication</a>. For full license information, see the <a href="uncopyright.xhtml">Uncopyright</a> at the end of this ebook.</p>
 			<p>Standard Ebooks is a volunteer-driven project that produces ebook editions of public domain literature using modern typography, technology, and editorial standards, and distributes them free of cost. You can download this and other ebooks carefully produced for true book lovers at <a href="https://standardebooks.org">standardebooks.org</a>.</p>
 		</section>


### PR DESCRIPTION
The currently linked sources are [dead](http://archive.rc.umd.edu/editions/LB/html/Lb05-1.html) [links](http://archive.rc.umd.edu/editions/LB/html/Lb05-2.html) because it seems that the University of Maryland stopped hosting Romantic Circles in the last few years. Luckily [Romantic Circles](http://romantic-circles.org/editions/LB/index.html) still exists and it looks like they're hosting the [same edition](http://ec2-52-90-79-236.compute-1.amazonaws.com/editions/LB/) that our production is based on, but they're hosting on an EC2 instance which seems kind of sketchy for me in the long term.

I took Internet Archive snapshots of the actual HTML ([vol. 1](https://web.archive.org/web/20211010215437/http://ec2-52-90-79-236.compute-1.amazonaws.com/cgi-bin/LB/sgml2html_lballads.pl?fname=Lb05-1.sgm) and [2](https://web.archive.org/web/20211010215601/http://ec2-52-90-79-236.compute-1.amazonaws.com/cgi-bin/LB/sgml2html_lballads.pl?fname=Lb05-2.sgm)) for the transcriptions so we don't lose them again, and added those as sources to replace the dead links. I also tracked down IA scans corresponding to the 1805 edition, since it seems that we might have been relying on the pictures on the Romantic Circles website originally.